### PR TITLE
fix issue in Chrome : Couldn't autodetect L.Icon.Default.imagePath

### DIFF
--- a/leaflet-core.html
+++ b/leaflet-core.html
@@ -648,20 +648,7 @@ add a marker with a popup text.
 				return;
 			}
 
-			var scripts = document.getElementsByTagName('link'),
-			    leafletRe = /[\/^]leaflet-map.html$/;
-
-			var i, len, src, matches, path;
-
-			for (i = 0, len = scripts.length; i < len; i++) {
-				src = scripts[i].href;
-				matches = src.match(leafletRe);
-
-				if (matches) {
-					path = src.split(leafletRe)[0];
-					L.Icon.Default.imagePath = (path ? path + '/' : '') + '../leaflet/dist/images';
-				}
-			}
+			L.Icon.Default.imagePath = this.resolveUrl('../leaflet/dist/images');
 		}
 
 		domReady() {


### PR DESCRIPTION
Hello ! 
We are using your web component on our "corporate" web site and we encounter a bug in Chrome.

```
Couldn't autodetect L.Icon.Default.imagePath, set it manually.
Uncaught Error: Couldn't autodetect L.Icon.Default.imagePath, set it manually.
    at e._getIconUrl (leaflet.js:7)
    at e._createIcon (leaflet.js:7)
    at e.createIcon (leaflet.js:7)
    at e._initIcon (leaflet.js:7)
    at e.onAdd (leaflet.js:7)
    at e._layerAdd (leaflet.js:6)
    at e.addLayer (leaflet.js:6)
    at e.addTo (leaflet.js:7)
    at HTMLElement._containerChanged (leaflet-marker.html:705)
    at Object.runObserverEffect [as fn] (property-effects.html:217)
    at runEffectsForProperty (property-effects.html:162)
    at runEffects (property-effects.html:128)
    at HTMLElement._propertiesChanged (property-effects.html:1711)
    at HTMLElement._flushProperties (properties-changed.html:341)
    at HTMLElement._flushProperties (property-effects.html:1559)
    at HTMLElement._invalidateProperties (property-effects.html:1531)
    at HTMLElement._setProperty (property-effects.html:1516)
    at HTMLElement.Object.defineProperty.set (properties-changed.html:150)
    at HTMLElement.registerMapOnChildren (leaflet-core.html:756)
    at HTMLElement.domReady (leaflet-core.html:737)
    at leaflet-core.html:642
```
In leaflet-core, the method `guessLeafletImagePath()` try to calculate the path of the default icon by looking at the leaflet-map link import tag `document.getElementsByTagName('link')`

But in the context evaluation in Chrome, `document` here represent the html document of the **index.html**, not the component that use leaflet-map directly.

A better solution is to use the path resolver : `this.resolveUrl('../leaflet/dist/images');`

Bugfix tested in Chrome 66.0.3359.170, Firefox 60.0 and Edge 17.17134

Thank you for the port to Polymer 2 of the original leaflet web component ! 👍 